### PR TITLE
Agrega confiugración notification_logging para logear las respuestas …

### DIFF
--- a/src/eventisc/__init__.py
+++ b/src/eventisc/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-__version__ = "0.1.0"
+__version__ = "0.1.1"
 
 import logging
 import importlib

--- a/src/eventisc/__init__.py
+++ b/src/eventisc/__init__.py
@@ -30,8 +30,9 @@ def eval_globals():
 
 class EventApp:
 
-    def __init__(self, name_prefix="", listeners=None):
+    def __init__(self, name_prefix="", listeners=None, notification_logging=None):
         self.name_prefix = name_prefix or ""
+        self.notification_logging = notification_logging or {}
         listeners = listeners or []
         self.listeners = []
         [self.add_listener(lis) for lis in listeners]
@@ -39,6 +40,7 @@ class EventApp:
     def add_listener(self, listener):
         if not isinstance(listener, Listener):
             listener = Listener.from_dict(listener)
+        listener.set_notification_logging(self.notification_logging)
         self.listeners.append(listener)
 
     def trigger(self, event_name, event_data):
@@ -108,6 +110,9 @@ class Listener(ABC):
         logger.info("EVENTISC_DRYRUN=Y _do_notify(%s, %s)", event_name, event_data)
         return True
 
+    def set_notification_logging(self, config):
+        self.notification_logging = config or {}
+
     @classmethod
     def format(self, value, event_name, event_data, **kwargs):
         """Formats a field that can be constant, proxy or format string of the event values"""
@@ -174,10 +179,14 @@ def read_config_file(config_file):
     elif format == "yaml":
         config = yaml.safe_load(config_file)
 
-    return config.get("name_prefix", None), config.get("listeners", [])
+    return (
+        config.get("name_prefix", None),
+        config.get("listeners", []),
+        config.get("notification_logging", None),
+    )
 
 
-def init_default_app(name_prefix=None, listeners=None, config_file=None):
+def init_default_app(name_prefix=None, listeners=None, config_file=None, notification_logging=None):
     global default_app
     if name_prefix is None and listeners is None and config_file is None:
         # Try reading from env
@@ -186,21 +195,33 @@ def init_default_app(name_prefix=None, listeners=None, config_file=None):
             name_prefix = env.str("EVENTISC_NAME_PREFIX", "")
             listeners = []
         else:
-            name_prefix, listeners = read_config_file(config_file)
+            name_prefix, listeners, config_notification_logging = read_config_file(config_file)
+            if notification_logging is None:
+                notification_logging = config_notification_logging
             if name_prefix is None:
                 name_prefix = env.str("EVENTISC_NAME_PREFIX", "")
     elif name_prefix is None and config_file is None:
         name_prefix = env.str("EVENTISC_NAME_PREFIX", "")
+    elif config_file is not None:
+        config_name_prefix, config_listeners, config_notification_logging = read_config_file(config_file)
+        if name_prefix is None:
+            name_prefix = config_name_prefix
+        if listeners is None:
+            listeners = config_listeners
+        if notification_logging is None:
+            notification_logging = config_notification_logging
 
-    default_app = create_app(name_prefix, listeners)
+    default_app = create_app(name_prefix, listeners, notification_logging=notification_logging)
     return default_app
 
 
-def create_app(name_prefix=None, listeners=None, config_file=None):
+def create_app(name_prefix=None, listeners=None, config_file=None, notification_logging=None):
     if config_file is not None:
-        name_prefix, listeners = read_config_file(config_file)
+        name_prefix, listeners, config_notification_logging = read_config_file(config_file)
+        if notification_logging is None:
+            notification_logging = config_notification_logging
 
-    return EventApp(name_prefix, listeners)
+    return EventApp(name_prefix, listeners, notification_logging=notification_logging)
 
 
 def get_current_app():

--- a/src/eventisc/http_listener.py
+++ b/src/eventisc/http_listener.py
@@ -1,6 +1,10 @@
 from urllib.parse import urlencode
+import logging
 import requests
 from . import Listener
+
+
+logger = logging.getLogger(__name__)
 
 
 class HttpListener(Listener):
@@ -18,6 +22,23 @@ class HttpListener(Listener):
         self.query_kwargs = query_kwargs
         self.data = data
         self.request_format = request_format
+        self.notification_logging = {}
+
+    def _log_response(self, event_name, url, resp):
+        if not self.notification_logging.get("enabled", False):
+            return
+
+        body = None
+        if self.notification_logging.get("log_response_body", True):
+            max_body_length = self.notification_logging.get("max_body_length", 2000)
+            body = resp.text[:max_body_length]
+            if len(resp.text) > max_body_length:
+                body += "..."
+
+        logger.info(
+            "eventisc notification response event=%s method=%s url=%s status=%s body=%r",
+            event_name, self.method.upper(), url, resp.status_code, body
+        )
 
     def _do_notify(self, event_name, event_data):
         if self.query_kwargs:
@@ -42,6 +63,10 @@ class HttpListener(Listener):
         else:
             resp = request_method(url, data=data, **self.requests_kwargs)
 
+        self._log_response(event_name, url, resp)
         resp.raise_for_status()
 
         return True
+
+    def set_notification_logging(self, config):
+        self.notification_logging = config or {}

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from unittest import TestCase
+from unittest import TestCase, mock
 import json
 import responses
 import eventisc
@@ -61,3 +61,69 @@ class TestHTTPListenerApp(TestCase):
             "foo": "bar"
         }
         assert request.headers["Authorization"] == "Basic bXl1c2VyOm15cGFzc3dvcmQ="
+
+
+    @responses.activate
+    def test_logs_http_response_when_enabled(self):
+        app = eventisc.create_app(
+            listeners=[
+                {
+                    "event_name_regex": ".*",
+                    "kind": "http",
+                    "url": "http://example.com/notify/{event_name}/",
+                }
+            ],
+            notification_logging={"enabled": True, "max_body_length": 5},
+        )
+
+        responses.add(
+            responses.POST,
+            "http://example.com/notify/something/",
+            body="abcdefghi",
+            status=200,
+        )
+
+        with mock.patch("eventisc.http_listener.logger.info") as info_log:
+            app.trigger("something", {"foo": "bar"})
+
+        info_log.assert_called_once_with(
+            "eventisc notification response event=%s method=%s url=%s status=%s body=%r",
+            "something",
+            "POST",
+            "http://example.com/notify/something/",
+            200,
+            "abcde...",
+        )
+
+    @responses.activate
+    def test_logs_http_response_before_raise_for_status(self):
+        app = eventisc.create_app(
+            listeners=[
+                {
+                    "event_name_regex": ".*",
+                    "kind": "http",
+                    "url": "http://example.com/notify/{event_name}/",
+                }
+            ],
+            notification_logging={"enabled": True},
+        )
+
+        responses.add(
+            responses.POST,
+            "http://example.com/notify/something/",
+            body="upstream error",
+            status=500,
+        )
+
+        with mock.patch("eventisc.http_listener.logger.info") as info_log:
+            with self.assertRaises(eventisc.http_listener.requests.HTTPError):
+                app.trigger("something", {"foo": "bar"})
+
+        info_log.assert_called_once_with(
+            "eventisc notification response event=%s method=%s url=%s status=%s body=%r",
+            "something",
+            "POST",
+            "http://example.com/notify/something/",
+            500,
+            "upstream error",
+        )


### PR DESCRIPTION
Tests:

```
(.venv) nelson@samoa:~/repo/event-isc  (http-listener-notification-logging) $ pytest 
==================================================================================== test session starts =====================================================================================
platform linux -- Python 3.12.3, pytest-9.0.3, pluggy-1.6.0
rootdir: /home/nelson/repo/event-isc
configfile: pyproject.toml
collected 17 items                                                                                                                                                                           

tests/test_celery.py ...                                                                                                                                                               [ 17%]
tests/test_events.py ........                                                                                                                                                          [ 64%]
tests/test_http.py ....                                                                                                                                                                [ 88%]
tests/test_rabbit.py ..                                                                                                                                                                [100%]

===================================================================================== 17 passed in 0.39s =====================================================================================
```